### PR TITLE
Decrease log level for unsupported statistics keys

### DIFF
--- a/pkg/ovs_exporter/ovs_exporter.go
+++ b/pkg/ovs_exporter/ovs_exporter.go
@@ -1120,7 +1120,7 @@ func (e *Exporter) GatherMetrics() {
 						intf.UUID,
 					))
 				default:
-					level.Error(e.logger).Log(
+					level.Debug(e.logger).Log(
 						"msg", "detected malformed interface statistics",
 						"system_id", e.Client.System.ID,
 						"key", key,


### PR DESCRIPTION
Interfaces may have a lot of statistics keys which are unexpected by this exporter. It does not break operation, but causes annoying spam of Error messages in the log. Let's set it to Debug.